### PR TITLE
Enable python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 
 python:
   - "3.7"
+  - "3.8"
 
 install:
   - pip install tox>=1.8

--- a/emmett/libs/sanitizer.py
+++ b/emmett/libs/sanitizer.py
@@ -10,7 +10,7 @@
 
 """
 
-from cgi import escape
+from html import escape
 from formatter import AbstractFormatter
 from html.entities import entitydefs
 from html.parser import HTMLParser

--- a/emmett/security.py
+++ b/emmett/security.py
@@ -69,7 +69,7 @@ def simple_hash(text, key='', salt='', digest_alg='md5'):
             get_digest(alg))
     elif key:  # use hmac
         digest_alg = get_digest(digest_alg)
-        h = hmac.new(to_bytes(key + salt), to_bytes(text), digest_alg)
+        h = hmac.new(to_bytes(key + salt), msg=to_bytes(text), digestmod=digest_alg)
     else:  # compatible with third party systems
         h = hashlib.new(digest_alg)
         h.update(to_bytes(text + salt))
@@ -124,7 +124,7 @@ def secure_dumps(data, encryption_key, hash_key=None, compression_level=None):
     key = _pad(to_bytes(encryption_key[:32]))
     aes = pyaes.AESModeOfOperationCFB(key, iv=key[:16], segment_size=8)
     encrypted_data = base64.urlsafe_b64encode(aes.encrypt(_pad(dump)))
-    signature = hmac.new(to_bytes(hash_key), encrypted_data).hexdigest()
+    signature = hmac.new(to_bytes(hash_key), msg=encrypted_data, digestmod='md5').hexdigest()
     return signature + ':' + encrypted_data.decode('utf8')
 
 
@@ -135,7 +135,7 @@ def secure_loads(data, encryption_key, hash_key=None, compression_level=None):
         hash_key = hashlib_sha1(encryption_key).hexdigest()
     signature, encrypted_data = data.split(':', 1)
     actual_signature = hmac.new(
-        to_bytes(hash_key), to_bytes(encrypted_data)).hexdigest()
+        to_bytes(hash_key), msg=to_bytes(encrypted_data), digestmod='md5').hexdigest()
     if signature != actual_signature:
         return None
     key = _pad(to_bytes(encryption_key[:32]))

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if platform.system() == 'Windows' or platform.system().startswith('CYGWIN'):
 else:
     requirements = sorted(_requirements_basic + [
         'httptools~=0.0.13',
-        'uvloop~=0.13.0'
+        'uvloop~=0.14.0'
     ])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py37,py38
 
 [testenv]
 commands =


### PR DESCRIPTION
Hi @gi0baro,

In order to add `emmett` (aka `weppy`) in https://github.com/the-benchmarker/web-frameworks, it needs to be runnable on `python` **3.8**

:information_source: `python` **3.8** is the **current** `stable` :information_source: 

This `PR` :

+ [x] Use `html.escape` instead of `cgi.escape`, since this was removed

@see https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals
+ [x] Test code base against `python` **3.8**
+ [x] Add `python` **3.8** classifier
+ [x] Specify `uvloop` to be at minimum **0.14**, `0.13` is not suitable for python **3.8**
+ [x] Specify `digestmod`, since required on `python` **3.8**

@see https://docs.python.org/3/library/hmac.html#hmac.new

Regards,

-----------
Closes #251 