### PR TITLE
Add bin service

### DIFF
--- a/emmett/serializers.py
+++ b/emmett/serializers.py
@@ -95,3 +95,7 @@ def xml(value, encoding='UTF-8', key='document', quote=True):
     rv = ('<?xml version="1.0" encoding="%s"?>' % encoding) + \
         str(xml_encode(value, key, quote))
     return rv
+
+@Serializers.register_for('bin')
+def bin(value):
+    return value

--- a/emmett/tools/decorators.py
+++ b/emmett/tools/decorators.py
@@ -52,6 +52,10 @@ class service(Decorator):
     def xml(f):
         return service('xml')(f)
 
+    @staticmethod
+    def bin(f):
+        return service('bin')(f)
+
     def build_pipe(self):
         from .service import ServicePipe
         return ServicePipe(self.procedure)

--- a/emmett/tools/service.py
+++ b/emmett/tools/service.py
@@ -48,11 +48,25 @@ class XMLServicePipe(Pipe):
     def on_send(self, data):
         return self.encoder(data)
 
+class ASISServicePipe(Pipe):
+    __slots__ = ['encoder']
+    output = 'bytes'
+
+    def __init__(self):
+        self.encoder = Serializers.get_for('bin')
+
+    async def pipe_request(self, next_pipe, **kwargs):
+        current.response.headers._data['content-type'] = 'application/octet-stream'
+        return self.encoder(await next_pipe(**kwargs))
+
+    def on_send(self, data):
+        return self.encoder(data)
 
 def ServicePipe(procedure: str) -> Pipe:
     pipe_cls = {
         'json': JSONServicePipe,
-        'xml': XMLServicePipe
+        'xml': XMLServicePipe,
+        'bin': ASISServicePipe,
     }.get(procedure)
     if not pipe_cls:
         raise RuntimeError(


### PR DESCRIPTION
Dear gi0baro, I absolutely love your Emmett framework ! My use-case for it is a web search-and-retrieve interface to an object storage based archive. When the user selects files to be downloaded from the archive they are added to a ZIP file and then get offered for download to the client by means of the "Content-Disposition": "attachment, filename ..." header. This means I needed a service next to "xml" and "json" which basically does nothing but passing the original file to the user ( default service would unzip the file, luckily the "bytes" output existed already ). I'm far from a pro Python programmer so forgive me the "hack" but it works for me so far. I would be very interested in an official solution of course !
Many thanks,
Koen