### PR TITLE
Widget list id issue

### DIFF
--- a/emmett/forms.py
+++ b/emmett/forms.py
@@ -548,9 +548,9 @@ class FormStyle:
         )
 
     @staticmethod
-    def widget_list(field, value):
+    def widget_list(field, value, _id=None):
         options, _ = FormStyle._field_options(field)
-        return FormStyle.widget_multiple(None, field, value, options)
+        return FormStyle.widget_multiple(None, field, value, options, _id=_id)
 
     @staticmethod
     def widget_upload(attr, field, value, _class="upload", _id=None):


### PR DESCRIPTION
whenever widget_list had 0 items to display the emmett framework would give it _id which was not handeld in said function.