### PR TITLE
Security: Path Traversal in Internal Static File Handler

### DIFF
--- a/emmett/rsgi/handlers.py
+++ b/emmett/rsgi/handlers.py
@@ -40,7 +40,10 @@ class HTTPHandler(_HTTPHandler):
             file_name = path[12:]
             if not file_name:
                 return self._http_response(404)
-            static_file = os.path.join(os.path.dirname(__file__), "..", "assets", file_name)
+            assets_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "assets"))
+            static_file = os.path.realpath(os.path.join(assets_dir, file_name))
+            if not static_file.startswith(assets_dir + os.sep):
+                return self._http_response(404)
             if os.path.splitext(static_file)[1] == "html":
                 return self._http_response(404)
             return self._static_response(static_file)


### PR DESCRIPTION
## Problem

The `_static_handler` method constructs a file path from user-controlled URL path by slicing `path[12:]` and joining it directly with the assets directory using `os.path.join`. An attacker can use `../` sequences (e.g., `/__emmett__/../../etc/passwd`) to read arbitrary files outside the assets directory. The only check is for `.html` extension, which does not prevent traversal to other file types.

**Severity**: `high`
**File**: `emmett/rsgi/handlers.py`

## Solution

Sanitize the `file_name` by resolving the path and verifying it stays within the assets directory: `static_file = os.path.realpath(static_file)` then check `if not static_file.startswith(os.path.realpath(assets_dir)): return self._http_response(404)`

## Changes

- `emmett/rsgi/handlers.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
