### PR TITLE
fix: remove broken Polar funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 github: [gi0baro]
-polar: emmett-framework


### PR DESCRIPTION
## Summary
- remove the Polar funding slug that currently points to a 404 page
- keep the existing GitHub Sponsors entry intact

Fixes #567

## Verification
- curl -I -L https://polar.sh/emmett-framework returns 404
- git diff --check